### PR TITLE
Fix openapi on non default server-root

### DIFF
--- a/pkg/api/v1/api.go
+++ b/pkg/api/v1/api.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"net/http"
+	"path"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
@@ -37,6 +38,8 @@ func New(cfg *config.Config, uploads upload.Upload, registry *service.Registry) 
 
 		return nil
 	}
+
+	spec.Spec().BasePath = path.Join(cfg.Server.Root, spec.Spec().BasePath)
 
 	api := operations.NewGomematicAPI(spec)
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -69,7 +69,10 @@ func Server(cfg *config.Config, uploads upload.Upload, registry *service.Registr
 							"v1",
 							"swagger",
 						),
-						"/api/v1/docs",
+						path.Join(
+							cfg.Server.Root,
+							"/api/v1/docs",
+						),
 					))
 				}
 


### PR DESCRIPTION
This change rewrites the BasePath in the analyzed openapi spec to include the configured server-root.
Without this change no endpoint can actually be matched if server root does not equal '/'.
